### PR TITLE
Update Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -456,6 +456,7 @@ RUN jupyter labextension install @ijmbarr/jupyterlab_spellchecker
 
 # Copying config and fix permissions
 COPY jupyter_notebook_config.json /etc/jupyter/
+RUN fix-permissions $CONDA_DIR
 RUN fix-permissions /home/$NB_USER
 
 # Switch back to jovyan to avoid accidental container runs as root


### PR DESCRIPTION
After installing tabnine, permissions are not fixed, which causes not registering it in notebook server. Just added line to fix permissions in CONDA_DIR