### PR TITLE
add openssh-client to enable git clone via ssh

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
     locales \
     fonts-liberation \
     run-one \
+    openssh-client \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \

--- a/src/Dockerfile.usefulpackages
+++ b/src/Dockerfile.usefulpackages
@@ -1,4 +1,4 @@
-LABEL maintainer="Christoph Schranz <christoph.schranz@salzburgresearch.at>"
+LABEL authors="Christoph Schranz <christoph.schranz@salzburgresearch.at>, Mathematical Michael <consistentbayes@gmail.com>"
 
 USER root
 
@@ -16,7 +16,7 @@ RUN set -ex \
     graphviz==0.11 \
 ' \
  && apt-get update \
- && apt-get -y install htop apt-utils graphviz libgraphviz-dev \
+ && apt-get -y install htop apt-utils graphviz libgraphviz-dev openssh-client \
  && pip install --no-cache-dir $buildDeps
 
 # Install various extensions


### PR DESCRIPTION
I like to mount my `.ssh` and `.gitconfig` inside of containers, and was surprised to find myself unable to `git clone git@github.com: ...`, this addresses that. Adds about 7MB to docker image.