### PR TITLE
Optimize conda install in gpulibs

### DIFF
--- a/src/Dockerfile.gpulibs
+++ b/src/Dockerfile.gpulibs
@@ -9,17 +9,15 @@ RUN pip install --upgrade pip && \
 
 # Install PyTorch with dependencies
 RUN conda install --quiet --yes \
-    pyyaml mkl mkl-include setuptools cmake cffi typing
+    pyyaml mkl mkl-include setuptools cmake cffi typing && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
 
 # Check compatibility here:
 # https://pytorch.org/get-started/locally/
 # Installation via conda leads to errors installing cudatoolkit=10.1
-RUN pip install torch torchvision torchaudio torchviz
-
-# Clean installation
-RUN conda clean --all -f -y && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
+RUN pip install --no-cache-dir torch torchvision torchaudio torchviz
 
 USER root
 


### PR DESCRIPTION
This fixes #59, seems to save a bit less than 3GB. I also added the --no-cache-dir to the pip install in the same area, as that is what is used elsewhere in the dockerfile.

I wasn't sure if I should include an updated Dockerfile from `generate-Dockerfile.sh`, but I tried locally and checked that it still built successfully.