### PR TITLE
Some security fixes

### DIFF
--- a/src/Dockerfile.gpulibs
+++ b/src/Dockerfile.gpulibs
@@ -3,8 +3,9 @@ LABEL maintainer="Christoph Schranz <christoph.schranz@salzburgresearch.at>"
 # Install Tensorflow, check compatibility here:
 # https://www.tensorflow.org/install/source#gpu
 # installation via conda leads to errors in version 4.8.2
+# Pinning tensorflow to 2.8.0, which fixes many, many security vulnerabilities in previous versions
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir "tensorflow==2.6.2" && \
+    pip install --no-cache-dir "tensorflow==2.8.0" && \
     pip install --no-cache-dir keras
 
 # Install PyTorch with dependencies

--- a/src/Dockerfile.usefulpackages
+++ b/src/Dockerfile.usefulpackages
@@ -31,6 +31,18 @@ RUN pip install --no-cache-dir jupyter_contrib_nbextensions \
 #  jupyter nbextension enable codefolding/main
 RUN jupyter labextension install @ijmbarr/jupyterlab_spellchecker
 
+# clean staging folder with vulnerable npm packages from jupyterlab installs (builds) above
+RUN jupyter lab clean && \
+# delete private keys left in packages by other developers, which lead to failed security scans
+rm -f \
+  /opt/conda/lib/python3.9/site-packages/tornado/test/test.key \
+  /opt/julia/packages/MbedTLS/4YY6E/test/clntsrvr/test.key \
+  /opt/julia/packages/MbedTLS/4YY6E/test/key.pem \
+  /opt/julia-1.7.1/share/julia/stdlib/v1.7/LibGit2/test/keys/invalid \
+  /opt/julia-1.7.1/share/julia/stdlib/v1.7/LibGit2/test/keys/valid \
+  /opt/julia-1.7.1/share/julia/stdlib/v1.7/LibGit2/test/keys/valid-passphrase
+
+
 RUN fix-permissions /home/$NB_USER
 
 # Switch back to jovyan to avoid accidental container runs as root


### PR DESCRIPTION
tensorflow==2.8.0
delete private keys
`jupyter lab clean` to remove staging with vulnerable npm packages from builds