### PR TITLE
Clean up after apt get and don't install recommends

### DIFF
--- a/src/Dockerfile.gpulibs
+++ b/src/Dockerfile.gpulibs
@@ -30,8 +30,8 @@ USER root
 
 # Install nvtop to monitor the gpu tasks
 RUN apt-get update && \
-    apt-get install -y cmake libncurses5-dev libncursesw5-dev git && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends cmake libncurses5-dev libncursesw5-dev git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/Syllo/nvtop.git /run/nvtop && \
     mkdir -p /run/nvtop/build && cd /run/nvtop/build && \

--- a/src/Dockerfile.usefulpackages
+++ b/src/Dockerfile.usefulpackages
@@ -12,7 +12,8 @@ RUN set -ex \
     pytest==7.2.2 \
 ' \
  && apt-get update \
- && apt-get -y install htop apt-utils iputils-ping graphviz libgraphviz-dev openssh-client \
+ && apt-get -y install --no-install-recommends htop apt-utils iputils-ping graphviz libgraphviz-dev openssh-client \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* \
  && pip install --no-cache-dir $buildDeps
 
 # install extension manager


### PR DESCRIPTION
This is a small improvement to reduce the image size a bit. The principle is copied from [jupyter/docker-stacks/scipy-notebook](https://github.com/jupyter/docker-stacks/blob/main/scipy-notebook/Dockerfile#L24).