### PR TITLE
Consistently install as user and fix permissions

### DIFF
--- a/src/Dockerfile.gpulibs
+++ b/src/Dockerfile.gpulibs
@@ -3,12 +3,22 @@ LABEL maintainer="Christoph Schranz <christoph.schranz@salzburgresearch.at>, Mat
 # Install Tensorflow, check compatibility here:
 # https://www.tensorflow.org/install/source#gpu
 # installation via conda leads to errors in version 4.8.2
+USER ${NB_UID}
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir tensorflow==2.10.1 keras==2.10
+    pip install --no-cache-dir tensorflow==2.10.1 keras==2.10 && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+
 
 # Install PyTorch with dependencies
 RUN conda install --quiet --yes \
-    pyyaml mkl mkl-include setuptools cmake cffi typing
+    pyyaml mkl mkl-include setuptools cmake cffi typing && \
+    conda clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+
 
 # Check compatibility here:
 # https://pytorch.org/get-started/locally/
@@ -22,7 +32,10 @@ RUN set -ex \
     torchaudio==0.13.1 \
     torchviz==0.0.2 \
 ' \
- && pip install --no-cache-dir $buildDeps --extra-index-url https://download.pytorch.org/whl/cu116
+ && pip install --no-cache-dir $buildDeps --extra-index-url https://download.pytorch.org/whl/cu116 \
+ && fix-permissions "${CONDA_DIR}" \
+ && fix-permissions "/home/${NB_USER}"
+
 
 ENV CUDA_PATH=/opt/conda/
 
@@ -41,12 +54,13 @@ RUN git clone https://github.com/Syllo/nvtop.git /run/nvtop && \
     rm -rf /run/nvtop
 
 # reinstall nvcc with cuda-nvcc to install ptax
-RUN /opt/conda/bin/conda install -c nvidia cuda-nvcc -y
-RUN ln -s /opt/conda/bin/ptxas /usr/bin/ptxas
-
-# fix permissions of conda
-RUN conda clean --all -f -y && \
+USER $NB_UID
+RUN conda install -c nvidia cuda-nvcc -y && \
+    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
+
+USER root
+RUN ln -s /opt/conda/bin/ptxas /usr/bin/ptxas
 
 USER $NB_UID

--- a/src/Dockerfile.usefulpackages
+++ b/src/Dockerfile.usefulpackages
@@ -2,38 +2,38 @@ LABEL authors="Christoph Schranz <christoph.schranz@salzburgresearch.at>, Mathem
 
 USER root
 
-# fix permissions of conda
-RUN fix-permissions $CONDA_DIR
+# Install useful packages and Graphviz
+RUN apt-get update \
+ && apt-get -y install htop apt-utils iputils-ping graphviz libgraphviz-dev openssh-client
 
-# Install usefull packages and Graphviz
+USER $NB_UID
 RUN set -ex \
  && buildDeps=' \
     graphviz==0.19.1 \
     pytest==7.2.2 \
 ' \
- && apt-get update \
- && apt-get -y install htop apt-utils iputils-ping graphviz libgraphviz-dev openssh-client \
- && pip install --no-cache-dir $buildDeps
+ && pip install --no-cache-dir $buildDeps \
+ && fix-permissions "${CONDA_DIR}" \
+ && fix-permissions "/home/${NB_USER}"
 
-# install extension manager
-RUN pip install --no-cache-dir jupyter_contrib_nbextensions==0.7.0 \
-  jupyter_nbextensions_configurator==0.6.1
-
-# install git extension
-RUN pip install --no-cache-dir jupyterlab-git==0.41.0
-
-# install plotly extension
-RUN pip install --no-cache-dir plotly==5.13.1
-
-# install drawio and graphical extensions
-RUN pip install --no-cache-dir jupyterlab-drawio==0.9.0 rise==5.7.1
-RUN pip install --no-cache-dir ipyleaflet==0.17.2 ipywidgets==8.0.4
-
-# install spell checker
-RUN pip install --no-cache-dir jupyterlab-spellchecker==0.7.3
-
-# fix permissions of conda
-RUN fix-permissions /home/$NB_USER
+RUN pip install --no-cache-dir \
+    # install extension manager
+    jupyter_contrib_nbextensions==0.7.0 \
+    jupyter_nbextensions_configurator==0.6.1 \
+    # install git extension
+    jupyterlab-git==0.41.0 \
+    # install plotly extension
+    plotly==5.13.1 \
+    # install drawio and graphical extensions
+    jupyterlab-drawio==0.9.0 \
+    rise==5.7.1 \
+    ipyleaflet==0.17.2 \
+    ipywidgets==8.0.4 \
+    # install spell checker
+    jupyterlab-spellchecker==0.7.3 && \
+    # fix permissions of conda
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID


### PR DESCRIPTION
As in docker-stacks the python packages should be installed as user and, to reduce layer sizes, always fix permissions in the same RUN directive. Every file touched in a later RUN directive will appear in the new layer. Especially for TensorFlow and PyTorch this might result in quite large layers. This PR fixes these issues.

In docker-stacks mamba is used instead of conda. Do you like to switch as well?

This PR might interfere with #100, I might have to rebase.